### PR TITLE
Add U128 & U256 Type

### DIFF
--- a/.github/actions/install-solana/action.yml
+++ b/.github/actions/install-solana/action.yml
@@ -1,32 +1,64 @@
-name: Install Solana Validator
-description: Install a local solana validator for testing
+name: Install Local Solana Validator
+description: Installs and caches the specified solana validator version.
 
 inputs:
+  github-token:
+    description: 'GitHub token for API access'
+    required: true
   solana_version:
-    description: Version of Solana to install
+    description: Version of Solana to install. Numeric version like "1.2.3" are supported, as well as "stable" for the latest release
     required: true
 
 runs:
   using: "composite"
   steps:
+    - name: Get Solana Version
+      id: get-solana-version
+      run: |
+        if [ "${{ inputs.solana_version }}" = "stable" ]; then
+          echo "Resolving stable version from GitHub API..."
+          release_json=$(\
+            curl -s \
+            -H "Authorization: Bearer ${{ inputs.github-token }}" \
+            -H "Accept: application/json" \
+            https://api.github.com/repos/anza-xyz/agave/releases/latest \
+          )
+          release=$( echo "$release_json" | grep -m 1 '"tag_name"' | sed -ne 's/.*"tag_name": "\([^"]*\)".*/\1/p')
+          release="${release#v}"
+          echo "Using resolved version: $release"
+        else
+          release="${{ inputs.solana_version }}"
+          echo "Using direct version: $release"
+        fi
+        
+        if [ -z "$release" ]; then
+          echo "❌ Failed to resolve solana version:"
+          echo "${{ inputs.solana_version }}"
+          exit 1
+        fi
+        
+        echo "✅ Resolved version: $release"
+        echo "resolved_version=$release" >> $GITHUB_OUTPUT
+      shell: bash
+
     - name: Cache Solana Install
       if: ${{ !env.ACT }}
       id: cache-solana-install
       uses: actions/cache@v4
       with:
-        path: "$HOME/.local/share/solana/install/releases/${{ inputs.solana_version }}"
-        key: ${{ runner.os }}-Solana-v${{ inputs.solana_version  }}
+        path: "$HOME/.local/share/solana/install/releases/${{ steps.get-solana-version.outputs.resolved_version }}"
+        key: ${{ runner.os }}-Solana-v${{ steps.get-solana-version.outputs.resolved_version }}
 
     - name: Install Solana
       if: ${{ !env.ACT }} && steps.cache-solana-install.cache-hit != 'true'
       run: |
-        sh -c "$(curl -sSfL https://release.anza.xyz/v${{ inputs.solana_version }}/install)"
+        sh -c "$(curl -sSfL https://release.anza.xyz/v${{ steps.get-solana-version.outputs.resolved_version }}/install)"
       shell: bash
 
     - name: Set Active Solana Version
       run: |
         rm -f "$HOME/.local/share/solana/install/active_release"
-        ln -s "$HOME/.local/share/solana/install/releases/${{ inputs.solana_version }}/solana-release" "$HOME/.local/share/solana/install/active_release"
+        ln -s "$HOME/.local/share/solana/install/releases/${{ steps.get-solana-version.outputs.resolved_version }}/solana-release" "$HOME/.local/share/solana/install/active_release"
       shell: bash
 
     - name: Add Solana bin to Path

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,6 +32,7 @@ jobs:
       - name: Install Solana
         uses: ./.github/actions/install-solana
         with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           solana_version: ${{ matrix.solana }}
 
       - name: Start local validator

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        solana: ["1.18.14"]
+        solana: ["2.0.0", "stable"]
 
     steps:
       - name: Checkout

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -30,6 +30,7 @@ kotlin {
         val commonMain by getting {
             dependencies {
                 implementation(libs.kotlinx.serialization.json)
+                implementation(libs.multimult)
             }
         }
         val commonTest by getting {

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -30,6 +30,7 @@ kotlin {
         val commonMain by getting {
             dependencies {
                 implementation(libs.kotlinx.serialization.json)
+                implementation(libs.borsh)
                 implementation(libs.multimult)
             }
         }

--- a/core/src/commonMain/kotlin/com/solana/types/U128.kt
+++ b/core/src/commonMain/kotlin/com/solana/types/U128.kt
@@ -1,0 +1,123 @@
+package com.solana.types
+
+import com.funkatronics.multibase.MultiBase
+import kotlinx.serialization.Serializable
+
+@Serializable
+class U128 : Number, Comparable<U128> {
+    companion object {
+        /**
+         * A constant holding the minimum value an instance of U128 can have.
+         */
+        val MIN_VALUE: U128 = U128(ByteArray(SIZE_BYTES) { 0 })
+
+        /**
+         * A constant holding the maximum value an instance of U128 can have.
+         */
+        val MAX_VALUE: U128 = U128(ByteArray(SIZE_BYTES) { -1 })
+
+        /**
+         * A constant holding the maximum decimal value an instance of U128 can have,
+         * represented as a String.
+         */
+        const val MAX_VALUE_DECIMAL = "340282366920938463463374607431768211455"
+
+        /**
+         * The number of bytes used to represent an instance of U128 in a binary form.
+         */
+        const val SIZE_BYTES: Int = 16
+
+        /**
+         * The number of bits used to represent an instance of U128 in a binary form.
+         */
+        const val SIZE_BITS: Int = 128
+
+        private fun fromBigEndian(bytes: ByteArray): U128 {
+            require(bytes.size <= 16)
+            val padded = ByteArray(16)
+            // copy into the right end (big‑endian)
+            bytes.copyInto(padded, 16 - bytes.size)
+            return U128(padded.reversedArray()) // store little‑endian internally
+        }
+
+        fun parse(string: String): U128 {
+            require(string.isNotEmpty()) { "Invalid U128 String: Empty string" }
+            require(string.all { it in '0'..'9' }) { "Invalid U128 String: Non-digit character" }
+            require(string.length <= 39) { "Invalid U128 String: Too many digits for U128" }
+            if (string.length == 39) require(string <= MAX_VALUE_DECIMAL) {
+                "Invalid U128 String: Value exceeds U128 max"
+            }
+
+            // decode the string as a MultiBase Encoded Base10 String
+            return fromBigEndian(MultiBase.decode("9$string"))
+        }
+    }
+
+    private val bytes: ByteArray
+
+    private constructor(bytes: ByteArray) {
+        require(bytes.size == 16)
+        this.bytes = bytes
+    }
+
+    fun toByteArray(bigEndian: Boolean = false) =
+        if (bigEndian) bytes.reversedArray() else bytes
+
+    override fun toDouble(): Double {
+        // Use high precision path: convert to BigDecimal-like via division
+        // but since Double has only 53 bits of precision, we can safely
+        // approximate by combining the top 64 bits and scaling.
+        val hi = getULong(8) // bytes 8..15
+        val lo = getULong(0) // bytes 0..7
+        return hi.toDouble() * 1.8446744073709552E19 + lo.toDouble()
+        // 2^64 = 18446744073709551616
+    }
+
+    override fun toFloat(): Float = toDouble().toFloat()
+
+    override fun toLong(): Long {
+        return getULong(0).toLong()
+    }
+
+    override fun toInt(): Int {
+        return (getULong(0) and 0xFFFFFFFFu).toInt()
+    }
+
+    override fun toShort(): Short {
+        return (getULong(0) and 0xFFFFu).toShort()
+    }
+
+    override fun toByte(): Byte {
+        return (getULong(0) and 0xFFu).toByte()
+    }
+
+    override fun compareTo(other: U128): Int {
+        for (i in 15 downTo 0) {
+            val a = bytes[i].toInt() and 0xFF
+            val b = other.bytes[i].toInt() and 0xFF
+            if (a != b) return a.compareTo(b)
+        }
+        return 0
+    }
+
+    override fun hashCode(): Int {
+        return bytes.contentHashCode()
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+
+        other as U128
+
+        return bytes.contentEquals(other.bytes)
+    }
+
+    private fun getULong(offset: Int): ULong {
+        var v = 0UL
+        for (i in 0 until 8) {
+            v = v or ((bytes[offset + i].toULong() and 0xFFu) shl (8 * i))
+        }
+        return v
+    }
+}

--- a/core/src/commonMain/kotlin/com/solana/types/U128.kt
+++ b/core/src/commonMain/kotlin/com/solana/types/U128.kt
@@ -38,6 +38,8 @@ class U128 : Number, Comparable<U128> {
         const val SIZE_BITS: Int = 128
 
         fun parse(string: String): U128 {
+            // Remove underscores and trailing 'n'/'u' character that are sometimes preset in numeric literals
+            val string = string.replace(Regex("(_|n$|u$)"), "")
             require(string.isNotEmpty()) { "Invalid U128 String: Empty string" }
             require(string.all { it in '0'..'9' }) { "Invalid U128 String: Non-digit character" }
             require(string.length <= 39) { "Invalid U128 String: Too many digits for U128" }

--- a/core/src/commonMain/kotlin/com/solana/types/U128.kt
+++ b/core/src/commonMain/kotlin/com/solana/types/U128.kt
@@ -114,7 +114,6 @@ class U128 : Number, Comparable<U128> {
     }
 
     override fun toString(): String {
-        println(bytes.contentToString())
         if (bytes.all { it == 0.toByte() }) return "0"
         return MultiBase.Base10.encode(bytes.reversedArray()).drop(1).dropWhile { it == '0' }
     }

--- a/core/src/commonMain/kotlin/com/solana/types/U128.kt
+++ b/core/src/commonMain/kotlin/com/solana/types/U128.kt
@@ -114,8 +114,13 @@ class U128 : Number, Comparable<U128> {
     }
 
     override fun toString(): String {
-        if (bytes.all { it == 0.toByte() }) return "0"
-        return MultiBase.Base10.encode(bytes.reversedArray()).drop(1).dropWhile { it == '0' }
+        return if (bytes.any { it != 0.toByte() }) {
+            MultiBase.Base10.encode(bytes.reversedArray())
+                .drop(1) // remove the MultiBase identifier
+                .dropWhile { it == '0' } // drop leading zeros
+        } else {
+            "0" // bytes are all zero, just return zero string
+        }
     }
 
     private fun getULong(offset: Int): ULong {

--- a/core/src/commonMain/kotlin/com/solana/types/U128.kt
+++ b/core/src/commonMain/kotlin/com/solana/types/U128.kt
@@ -32,14 +32,6 @@ class U128 : Number, Comparable<U128> {
          */
         const val SIZE_BITS: Int = 128
 
-        private fun fromBigEndian(bytes: ByteArray): U128 {
-            require(bytes.size <= 16)
-            val padded = ByteArray(16)
-            // copy into the right end (big‑endian)
-            bytes.copyInto(padded, 16 - bytes.size)
-            return U128(padded.reversedArray()) // store little‑endian internally
-        }
-
         fun parse(string: String): U128 {
             require(string.isNotEmpty()) { "Invalid U128 String: Empty string" }
             require(string.all { it in '0'..'9' }) { "Invalid U128 String: Non-digit character" }
@@ -50,6 +42,14 @@ class U128 : Number, Comparable<U128> {
 
             // decode the string as a MultiBase Encoded Base10 String
             return fromBigEndian(MultiBase.decode("9$string"))
+        }
+
+        private fun fromBigEndian(bytes: ByteArray): U128 {
+            require(bytes.size <= 16)
+            val padded = ByteArray(16)
+            // copy into the right end (big‑endian)
+            bytes.copyInto(padded, 16 - bytes.size)
+            return U128(padded.reversedArray()) // store little‑endian internally
         }
     }
 
@@ -111,6 +111,12 @@ class U128 : Number, Comparable<U128> {
         other as U128
 
         return bytes.contentEquals(other.bytes)
+    }
+
+    override fun toString(): String {
+        println(bytes.contentToString())
+        if (bytes.all { it == 0.toByte() }) return "0"
+        return MultiBase.Base10.encode(bytes.reversedArray()).drop(1).dropWhile { it == '0' }
     }
 
     private fun getULong(offset: Int): ULong {

--- a/core/src/commonMain/kotlin/com/solana/util/Helpers.kt
+++ b/core/src/commonMain/kotlin/com/solana/util/Helpers.kt
@@ -1,6 +1,7 @@
 package com.solana.util
 
 fun divideBase10StringByLong(base10: String, divisor: Long): String {
+    require(base10.isNotEmpty()) { "Invalid Base10 String: Empty string" }
     require(base10.all { it in '0'..'9' }) { "Invalid Base10 String: Non-digit character" }
     // As result can be very large store it in string but since
     // we need to modify it very often so using string builder
@@ -10,9 +11,9 @@ fun divideBase10StringByLong(base10: String, divisor: Long): String {
     var carry = 0L
 
     // Iterate the dividend
-    for (i in base10.indices) {
+    base10.forEach { c ->
         // Prepare the number to be divided
-        val x: Long = (carry * 10 + base10[i].toString().toInt(10))
+        val x: Long = (carry * 10 + c.digitToInt(10))
 
         // Append the result with partial quotient
         result.append(x / divisor)
@@ -22,13 +23,7 @@ fun divideBase10StringByLong(base10: String, divisor: Long): String {
     }
 
     // Remove any leading zeros
-    for (i in 0..<result.length) {
-        if (result[i] != '0') {
-            // Return the result
-            return result.substring(i)
-        }
+    return result.trimStart('0').run {
+        if (isEmpty()) "0" else toString()
     }
-
-    // Return empty string if number is empty
-    return ""
 }

--- a/core/src/commonMain/kotlin/com/solana/util/Helpers.kt
+++ b/core/src/commonMain/kotlin/com/solana/util/Helpers.kt
@@ -1,0 +1,34 @@
+package com.solana.util
+
+fun divideBase10StringByLong(base10: String, divisor: Long): String {
+    require(base10.all { it in '0'..'9' }) { "Invalid Base10 String: Non-digit character" }
+    // As result can be very large store it in string but since
+    // we need to modify it very often so using string builder
+    val result = StringBuilder()
+
+    // Initially the carry would be zero
+    var carry = 0L
+
+    // Iterate the dividend
+    for (i in base10.indices) {
+        // Prepare the number to be divided
+        val x: Long = (carry * 10 + base10[i].toString().toInt(10))
+
+        // Append the result with partial quotient
+        result.append(x / divisor)
+
+        // Prepare the carry for the next Iteration
+        carry = x % divisor
+    }
+
+    // Remove any leading zeros
+    for (i in 0..<result.length) {
+        if (result[i] != '0') {
+            // Return the result
+            return result.substring(i)
+        }
+    }
+
+    // Return empty string if number is empty
+    return ""
+}

--- a/core/src/commonTest/kotlin/com/solana/types/u128/U128CompareToTest.kt
+++ b/core/src/commonTest/kotlin/com/solana/types/u128/U128CompareToTest.kt
@@ -1,0 +1,50 @@
+package com.solana.types.u128
+
+import com.solana.types.U128
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class U128CompareToTest {
+
+    @Test
+    fun `U128 compareTo returns 0 for equivalent U128 values`() {
+        // given
+        val firstU128 = U128.parse("1234567890")
+        val otherU128 = U128.parse("1234567890")
+        val expectedComparison = 0
+
+        // when
+        val actualComparison = firstU128.compareTo(otherU128)
+
+        // then
+        assertEquals(expectedComparison, actualComparison)
+    }
+
+    @Test
+    fun `U128 compareTo returns -1 for comparison to larger U128 value`() {
+        // given
+        val firstU128 = U128.parse("1234567890")
+        val otherU128 = U128.parse("1234567891")
+        val expectedComparison = -1
+
+        // when
+        val actualComparison = firstU128.compareTo(otherU128)
+
+        // then
+        assertEquals(expectedComparison, actualComparison)
+    }
+
+    @Test
+    fun `U128 compareTo returns -1 for equivalent U128 values`() {
+        // given
+        val firstU128 = U128.parse("1234567891")
+        val otherU128 = U128.parse("1234567890")
+        val expectedComparison = 1
+
+        // when
+        val actualComparison = firstU128.compareTo(otherU128)
+
+        // then
+        assertEquals(expectedComparison, actualComparison)
+    }
+}

--- a/core/src/commonTest/kotlin/com/solana/types/u128/U128DivideTest.kt
+++ b/core/src/commonTest/kotlin/com/solana/types/u128/U128DivideTest.kt
@@ -1,0 +1,22 @@
+package com.solana.types.u128
+
+import com.solana.types.U128
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class U128DivideTest {
+
+    @Test
+    fun `divide U128 value by long produces integer division result`() {
+        // given
+        val dividend = U128.parse("2378567835")
+        val divisor = 1256L
+        val expectedResult = U128.parse("1893764")
+
+        // when
+        val product = dividend/divisor
+
+        // then
+        assertEquals(expectedResult, product)
+    }
+}

--- a/core/src/commonTest/kotlin/com/solana/types/u128/U128DivideTest.kt
+++ b/core/src/commonTest/kotlin/com/solana/types/u128/U128DivideTest.kt
@@ -1,8 +1,10 @@
 package com.solana.types.u128
 
 import com.solana.types.U128
+import com.solana.types.U256
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 
 class U128DivideTest {
 
@@ -14,9 +16,38 @@ class U128DivideTest {
         val expectedResult = U128.parse("1893764")
 
         // when
-        val product = dividend/divisor
+        val result = dividend/divisor
 
         // then
-        assertEquals(expectedResult, product)
+        assertEquals(expectedResult, result)
+    }
+
+    @Test
+    fun `divide U128 0 value by long produces 0`() {
+        // given
+        val dividend = U128.parse("0")
+        val divisor = 1256L
+        val expectedResult = U128.parse("0")
+
+        // when
+        val result = dividend/divisor
+
+        // then
+        assertEquals(expectedResult, result)
+    }
+
+    @Test
+    fun `divide U128 value by 0 produces Error`() {
+        // given
+        val dividend = U128.parse("324862882325")
+        val divisor = 0L
+
+        // when
+        fun result() = dividend/divisor
+
+        // then
+        assertFailsWith(ArithmeticException::class) {
+            result()
+        }
     }
 }

--- a/core/src/commonTest/kotlin/com/solana/types/u128/U128DivideTest.kt
+++ b/core/src/commonTest/kotlin/com/solana/types/u128/U128DivideTest.kt
@@ -46,7 +46,7 @@ class U128DivideTest {
         fun result() = dividend/divisor
 
         // then
-        assertFailsWith(ArithmeticException::class) {
+        assertFailsWith<Exception>("divide by zero") {
             result()
         }
     }

--- a/core/src/commonTest/kotlin/com/solana/types/u128/U128MultiplyTest.kt
+++ b/core/src/commonTest/kotlin/com/solana/types/u128/U128MultiplyTest.kt
@@ -49,4 +49,18 @@ class U128MultiplyTest {
         // then
         assertEquals(expectedResult, product)
     }
+
+    @Test
+    fun `multiplying U128 value by 0 produces 0`() {
+        // given
+        val value1 = U128.parse("76432623462")
+        val value2 = U128.parse("0")
+        val expectedResult = U256.parse("0")
+
+        // when
+        val product = value1*value2
+
+        // then
+        assertEquals(expectedResult, product)
+    }
 }

--- a/core/src/commonTest/kotlin/com/solana/types/u128/U128MultiplyTest.kt
+++ b/core/src/commonTest/kotlin/com/solana/types/u128/U128MultiplyTest.kt
@@ -1,0 +1,52 @@
+package com.solana.types.u128
+
+import com.solana.types.U128
+import com.solana.types.U256
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class U128MultiplyTest {
+
+    @Test
+    fun `multiplying U128 small values produces product`() {
+        // given
+        val value1 = U128.parse("76")
+        val value2 = U128.parse("28568")
+        val expectedResult = U256.parse("2171168")
+
+        // when
+        val product = value1*value2
+
+        // then
+        assertEquals(expectedResult, product)
+    }
+
+    @Test
+    fun `multiplying U128 medium values produces product`() {
+        // given
+        val value1 = U128.parse("4032822279924")
+        val value2 = U128.parse("1361845238")
+        val expectedResult = U256.parse("5492079817614802401912")
+
+        // when
+        val product = value1*value2
+
+        // then
+        assertEquals(expectedResult, product)
+    }
+
+    @Test
+    fun `multiplying U128 large values produces product`() {
+        // given
+        val value1 = U128.MAX_VALUE
+        val value2 = U128.MAX_VALUE
+        val expectedResult =
+            U256.parse("115792089237316195423570985008687907852589419931798687112530834793049593217025")
+
+        // when
+        val product = value1*value2
+
+        // then
+        assertEquals(expectedResult, product)
+    }
+}

--- a/core/src/commonTest/kotlin/com/solana/types/u128/U128ParseTest.kt
+++ b/core/src/commonTest/kotlin/com/solana/types/u128/U128ParseTest.kt
@@ -9,7 +9,7 @@ import kotlin.test.assertFailsWith
 class U128ParseTest {
 
     @Test
-    fun `parse Int string string successfully parses Int value`() {
+    fun `parse Int string successfully parses Int value`() {
         // given
         val intString = "1234"
         val expected = byteArrayOf(
@@ -80,5 +80,65 @@ class U128ParseTest {
         assertFailsWith(IllegalArgumentException::class) {
             U128.parse(u129String)
         }
+    }
+
+    @Test
+    fun `parse UInt string successfully parses UInt value`() {
+        // given
+        val intString = "1234u"
+        val expected = byteArrayOf(
+            -46, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
+        ) // 1234 bytes, little-endian
+
+        // when
+        val result = U128.parse(intString)
+
+        // then
+        assertContentEquals(expected, result.toByteArray())
+    }
+
+    @Test
+    fun `parse underscore separated string successfully parses value`() {
+        // given
+        val intString = "1_234"
+        val expected = byteArrayOf(
+            -46, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
+        ) // 1234 bytes, little-endian
+
+        // when
+        val result = U128.parse(intString)
+
+        // then
+        assertContentEquals(expected, result.toByteArray())
+    }
+
+    @Test
+    fun `parse BigInt literal string successfully parses value`() {
+        // given
+        val intString = "1234n"
+        val expected = byteArrayOf(
+            -46, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
+        ) // 1234 bytes, little-endian
+
+        // when
+        val result = U128.parse(intString)
+
+        // then
+        assertContentEquals(expected, result.toByteArray())
+    }
+
+    @Test
+    fun `parse underscore separated BigInt literal string successfully parses value`() {
+        // given
+        val intString = "1_234n"
+        val expected = byteArrayOf(
+            -46, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
+        ) // 1234 bytes, little-endian
+
+        // when
+        val result = U128.parse(intString)
+
+        // then
+        assertContentEquals(expected, result.toByteArray())
     }
 }

--- a/core/src/commonTest/kotlin/com/solana/types/u128/U128ParseTest.kt
+++ b/core/src/commonTest/kotlin/com/solana/types/u128/U128ParseTest.kt
@@ -1,0 +1,84 @@
+package com.solana.types.u128
+
+import com.solana.types.U128
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class U128ParseTest {
+
+    @Test
+    fun `parse Int string string successfully parses Int value`() {
+        // given
+        val intString = "1234"
+        val expected = byteArrayOf(
+            -46, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
+        ) // 1234 bytes, little-endian
+
+        // when
+        val result = U128.parse(intString)
+
+        // then
+        assertContentEquals(expected, result.toByteArray())
+    }
+
+    @Test
+    fun `parse U128 max value string successfully parses`() {
+        // given
+        val u128String = U128.MAX_VALUE_DECIMAL
+        val expected = U128.MAX_VALUE
+
+        // when
+        val result = U128.parse(u128String)
+
+        // then
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun `parse U128 min value string successfully parses`() {
+        // given
+        val zeroString = "0"
+        val expected = U128.MIN_VALUE
+
+        // when
+        val result = U128.parse(zeroString)
+
+        // then
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun `parse empty string throws IllegalArgumentException`() {
+        // given
+        val emptyString = ""
+
+        // then
+        assertFailsWith(IllegalArgumentException::class) {
+            U128.parse(emptyString)
+        }
+    }
+
+    @Test
+    fun `parse non-numeric string throws IllegalArgumentException`() {
+        // given
+        val illegalString = "1234abcd"
+
+        // then
+        assertFailsWith(IllegalArgumentException::class) {
+            U128.parse(illegalString)
+        }
+    }
+
+    @Test
+    fun `parse input string greater than U128 MAX_VALUE throws IllegalArgumentException`() {
+        // given
+        val u129String = "340282366920938463463374607431768211456" // U128.MAX_VALUE + 1
+
+        // then
+        assertFailsWith(IllegalArgumentException::class) {
+            U128.parse(u129String)
+        }
+    }
+}

--- a/core/src/commonTest/kotlin/com/solana/types/u128/U128SerializationTest.kt
+++ b/core/src/commonTest/kotlin/com/solana/types/u128/U128SerializationTest.kt
@@ -78,7 +78,7 @@ class U128SerializationTest {
     }
 
     @Test
-    fun `U128 serializes MAX_VALUE to Borsh as ByteArray(16) { -1 }`() {
+    fun `U128 serializes MAX_VALUE to Borsh as max value ByteArray`() {
         // given
         @Serializable
         data class TestClass(val u128: U128)

--- a/core/src/commonTest/kotlin/com/solana/types/u128/U128SerializationTest.kt
+++ b/core/src/commonTest/kotlin/com/solana/types/u128/U128SerializationTest.kt
@@ -1,0 +1,131 @@
+package com.solana.types.u128
+
+import com.funkatronics.kborsh.Borsh
+import com.solana.types.U128
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.encodeToByteArray
+import kotlinx.serialization.json.Json
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+
+class U128SerializationTest {
+
+    @Test
+    fun `U128 serializes to JSON as string`() {
+        // given
+        @Serializable
+        data class TestClass(val u128: U128)
+        val u128 = U128.parse("12345")
+        val expectedJson = """
+            {"u128":"12345"}
+        """.trimIndent()
+
+        // when
+        val actualJson = Json.encodeToString<TestClass>(TestClass(u128))
+
+        // then
+        assertEquals(expectedJson, actualJson)
+    }
+
+    @Test
+    fun `U128 serializes small number to Borsh as 16 length byte string`() {
+        // given
+        @Serializable
+        data class TestClass(val u128: U128)
+        val u128 = U128.parse("12345")
+        val expectedBinary = byteArrayOf(
+            57, 48, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
+        )
+
+        // when
+        val actualBinary = Borsh.encodeToByteArray<TestClass>(TestClass(u128))
+
+        // then
+        assertContentEquals(expectedBinary, actualBinary)
+    }
+
+    @Test
+    fun `U128 serializes medium number to Borsh as 16 length byte string`() {
+        // given
+        @Serializable
+        data class TestClass(val u128: U128)
+        val u128 = U128.parse("9223372036854775810")
+        val expectedBinary = byteArrayOf(
+            2, 0, 0, 0, 0, 0, 0, -128, 0, 0, 0, 0, 0, 0, 0, 0
+        )
+        // when
+        val actualBinary = Borsh.encodeToByteArray<TestClass>(TestClass(u128))
+
+        // then
+        assertContentEquals(expectedBinary, actualBinary)
+    }
+
+    @Test
+    fun `U128 serializes large number to Borsh as 16 length byte string`() {
+        // given
+        @Serializable
+        data class TestClass(val u128: U128)
+        val u128 = U128.parse("987654321012345678901234567890")
+        val expectedBinary = byteArrayOf(
+            -46, 10, -65, -41, -116, -128, 101, 80, -103, -127, 72, 119, 12, 0, 0, 0
+        )
+        // when
+        val actualBinary = Borsh.encodeToByteArray<TestClass>(TestClass(u128))
+
+        // then
+        assertContentEquals(expectedBinary, actualBinary)
+    }
+
+    @Test
+    fun `U128 serializes MAX_VALUE to Borsh as ByteArray(16) { -1 }`() {
+        // given
+        @Serializable
+        data class TestClass(val u128: U128)
+        val u128 = U128.MAX_VALUE
+        val expectedBinary = byteArrayOf(
+            -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1
+        )
+
+        // when
+        val actualBinary = Borsh.encodeToByteArray<TestClass>(TestClass(u128))
+
+        // then
+        assertContentEquals(expectedBinary, actualBinary)
+    }
+
+    @Test
+    fun `Class containing U128 values serializes to Borsh ByteArray`() {
+        // given
+        @Serializable
+        data class TestClass(
+            val string: String,
+            val u128a: U128,
+            val u128b: U128,
+            val boolean: Boolean,
+            val u128c: U128
+        )
+        val testInstance = TestClass(
+            "Hello World!",
+            U128.MAX_VALUE,
+            U128.MIN_VALUE,
+            false,
+            U128.parse("1234567890")
+        )
+        val expectedBinary = byteArrayOf(
+            12, 0, 0, 0, 72, 101, 108, 108, 111, 32, 87, 111, 114, 108, 100, 33, // "Hello World!"
+            -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, // U128.MAX_VALUE
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, // U128.MIN_VALUE
+            0, // false boolean
+            -46, 2, -106, 73, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 // U128(1234567890)
+        )
+
+        // when
+        val actualBinary = Borsh.encodeToByteArray<TestClass>(testInstance)
+        val actualDecoded = Borsh.decodeFromByteArray(TestClass.serializer(), actualBinary)
+
+        // then
+        assertContentEquals(expectedBinary, actualBinary)
+        assertEquals(testInstance, actualDecoded)
+    }
+}

--- a/core/src/commonTest/kotlin/com/solana/types/u128/U128ToByteTest.kt
+++ b/core/src/commonTest/kotlin/com/solana/types/u128/U128ToByteTest.kt
@@ -1,0 +1,48 @@
+package com.solana.types.u128
+
+import com.solana.types.U128
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class U128ToByteTest {
+
+    @Test
+    fun `U128 toByte() converts to equivalent Byte`() {
+        // given
+        val byteValue: Byte = 123
+        val u128 = U128.parse("123")
+
+        // when
+        val result = u128.toByte()
+
+        // then
+        assertEquals(byteValue, result)
+    }
+
+    @Test
+    fun `U128 toByte() converts max value Byte`() {
+        // given
+        val byteValue: Byte = Byte.MAX_VALUE // 127
+        val u128 = U128.parse("127")
+
+        // when
+        val result = u128.toByte()
+
+        // then
+        assertEquals(byteValue, result)
+    }
+
+    @Test
+    fun `U128 toByte() converts to truncated Byte`() {
+        // given
+        val intValue = 300 // larger than Byte.MAX_VALUE
+        val u128 = U128.parse(intValue.toString())
+        val expected = intValue.toByte() // truncates to 44
+
+        // when
+        val result = u128.toByte()
+
+        // then
+        assertEquals(expected, result)
+    }
+}

--- a/core/src/commonTest/kotlin/com/solana/types/u128/U128ToByteTest.kt
+++ b/core/src/commonTest/kotlin/com/solana/types/u128/U128ToByteTest.kt
@@ -7,7 +7,7 @@ import kotlin.test.assertEquals
 class U128ToByteTest {
 
     @Test
-    fun `U128 toByte() converts to equivalent Byte`() {
+    fun `U128 toByte converts to equivalent Byte`() {
         // given
         val byteValue: Byte = 123
         val u128 = U128.parse("123")
@@ -20,7 +20,7 @@ class U128ToByteTest {
     }
 
     @Test
-    fun `U128 toByte() converts max value Byte`() {
+    fun `U128 toByte converts max value Byte`() {
         // given
         val byteValue: Byte = Byte.MAX_VALUE // 127
         val u128 = U128.parse("127")
@@ -33,7 +33,7 @@ class U128ToByteTest {
     }
 
     @Test
-    fun `U128 toByte() converts to truncated Byte`() {
+    fun `U128 toByte converts to truncated Byte`() {
         // given
         val intValue = 300 // larger than Byte.MAX_VALUE
         val u128 = U128.parse(intValue.toString())

--- a/core/src/commonTest/kotlin/com/solana/types/u128/U128ToDoubleTest.kt
+++ b/core/src/commonTest/kotlin/com/solana/types/u128/U128ToDoubleTest.kt
@@ -7,7 +7,7 @@ import kotlin.test.assertEquals
 class U128ToDoubleTest {
 
     @Test
-    fun `U128 toDouble() converts to equivalent Double for small values`() {
+    fun `U128 toDouble converts to equivalent Double for small values`() {
         // given
         val u128 = U128.parse("12345")
         val expected = 12345.0
@@ -20,7 +20,7 @@ class U128ToDoubleTest {
     }
 
     @Test
-    fun `U128 toDouble() converts max precise integer within Double mantissa`() {
+    fun `U128 toDouble converts max precise integer within Double mantissa`() {
         // given
         // 2^53 = 9007199254740992 is the largest integer exactly representable in Double
         val value = 9007199254740992UL
@@ -35,7 +35,7 @@ class U128ToDoubleTest {
     }
 
     @Test
-    fun `U128 toDouble() converts max U128 value with expected precision loss`() {
+    fun `U128 toDouble converts max U128 value with expected precision loss`() {
         // given
         val u128 = U128.MAX_VALUE
         val expected = 3.402823669209385E38

--- a/core/src/commonTest/kotlin/com/solana/types/u128/U128ToDoubleTest.kt
+++ b/core/src/commonTest/kotlin/com/solana/types/u128/U128ToDoubleTest.kt
@@ -1,0 +1,49 @@
+package com.solana.types.u128
+
+import com.solana.types.U128
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class U128ToDoubleTest {
+
+    @Test
+    fun `U128 toDouble() converts to equivalent Double for small values`() {
+        // given
+        val u128 = U128.parse("12345")
+        val expected = 12345.0
+
+        // when
+        val result = u128.toDouble()
+
+        // then
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun `U128 toDouble() converts max precise integer within Double mantissa`() {
+        // given
+        // 2^53 = 9007199254740992 is the largest integer exactly representable in Double
+        val value = 9007199254740992UL
+        val u128 = U128.parse(value.toString())
+        val expected = 9007199254740992.0
+
+        // when
+        val result = u128.toDouble()
+
+        // then
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun `U128 toDouble() converts max U128 value with expected precision loss`() {
+        // given
+        val u128 = U128.MAX_VALUE
+        val expected = 3.402823669209385E38
+
+        // when
+        val result = u128.toDouble()
+
+        // then
+        assertEquals(expected, result, 1e-9)
+    }
+}

--- a/core/src/commonTest/kotlin/com/solana/types/u128/U128ToFloatTest.kt
+++ b/core/src/commonTest/kotlin/com/solana/types/u128/U128ToFloatTest.kt
@@ -1,0 +1,63 @@
+package com.solana.types.u128
+
+import com.solana.types.U128
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class U128ToFloatTest {
+
+    @Test
+    fun `U128 toFloat() converts small values exactly`() {
+        // given
+        val u128 = U128.parse("12345")
+        val expected = 12345f
+
+        // when
+        val result = u128.toFloat()
+
+        // then
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun `U128 toFloat() converts max precise integer within Float mantissa`() {
+        // given
+        // 2^24 = 16777216 is the largest integer exactly representable in Float
+        val value = 16777216UL
+        val u128 = U128.parse(value.toString())
+        val expected = 16777216f
+
+        // when
+        val result = u128.toFloat()
+
+        // then
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun `U128 toFloat() converts imprecise but finite values larger than 2^24`() {
+        // given
+        val bigButFinite = 100_000_000UL // > 2^24 but << Float.MAX_VALUE
+        val u128 = U128.parse(bigButFinite.toString())
+        val expected = 100_000_000f
+
+        // when
+        val result = u128.toFloat()
+
+        // then
+        assertEquals(expected, result, 0.0001f)
+    }
+
+    @Test
+    fun `U128 toFloat() converts very large U128 with expected overflow to Infinity`() {
+        // given
+        val u128 = U128.MAX_VALUE
+        val expected = Float.POSITIVE_INFINITY
+
+        // when
+        val result = u128.toFloat()
+
+        // then
+        assertEquals(expected, result)
+    }
+}

--- a/core/src/commonTest/kotlin/com/solana/types/u128/U128ToFloatTest.kt
+++ b/core/src/commonTest/kotlin/com/solana/types/u128/U128ToFloatTest.kt
@@ -7,7 +7,7 @@ import kotlin.test.assertEquals
 class U128ToFloatTest {
 
     @Test
-    fun `U128 toFloat() converts small values exactly`() {
+    fun `U128 toFloat converts small values exactly`() {
         // given
         val u128 = U128.parse("12345")
         val expected = 12345f
@@ -20,7 +20,7 @@ class U128ToFloatTest {
     }
 
     @Test
-    fun `U128 toFloat() converts max precise integer within Float mantissa`() {
+    fun `U128 toFloat converts max precise integer within Float mantissa`() {
         // given
         // 2^24 = 16777216 is the largest integer exactly representable in Float
         val value = 16777216UL
@@ -35,7 +35,7 @@ class U128ToFloatTest {
     }
 
     @Test
-    fun `U128 toFloat() converts imprecise but finite values larger than 2^24`() {
+    fun `U128 toFloat converts imprecise but finite values larger than 2^24`() {
         // given
         val bigButFinite = 100_000_000UL // > 2^24 but << Float.MAX_VALUE
         val u128 = U128.parse(bigButFinite.toString())
@@ -46,18 +46,5 @@ class U128ToFloatTest {
 
         // then
         assertEquals(expected, result, 0.0001f)
-    }
-
-    @Test
-    fun `U128 toFloat() converts very large U128 with expected overflow to Infinity`() {
-        // given
-        val u128 = U128.MAX_VALUE
-        val expected = Float.POSITIVE_INFINITY
-
-        // when
-        val result = u128.toFloat()
-
-        // then
-        assertEquals(expected, result)
     }
 }

--- a/core/src/commonTest/kotlin/com/solana/types/u128/U128ToIntTest.kt
+++ b/core/src/commonTest/kotlin/com/solana/types/u128/U128ToIntTest.kt
@@ -1,0 +1,48 @@
+package com.solana.types.u128
+
+import com.solana.types.U128
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class U128ToIntTest {
+
+    @Test
+    fun `U128 toInt() converts to equivalent Int`() {
+        // given
+        val intValue = 1234
+        val u128 = U128.parse("1234")
+
+        // when
+        val result = u128.toInt()
+
+        // then
+        assertEquals(intValue, result)
+    }
+
+    @Test
+    fun `U128 toInt() converts max value Int`() {
+        // given
+        val intValue = Int.MAX_VALUE
+        val u128 = U128.parse("2147483647")
+
+        // when
+        val result = u128.toInt()
+
+        // then
+        assertEquals(intValue, result)
+    }
+
+    @Test
+    fun `U128 toInt() converts to truncated Int`() {
+        // given
+        val longValue = 2147483652
+        val u128 = U128.parse("2147483652")
+        val expected = longValue.toInt()
+
+        // when
+        val result = u128.toInt()
+
+        // then
+        assertEquals(expected, result)
+    }
+}

--- a/core/src/commonTest/kotlin/com/solana/types/u128/U128ToIntTest.kt
+++ b/core/src/commonTest/kotlin/com/solana/types/u128/U128ToIntTest.kt
@@ -7,7 +7,7 @@ import kotlin.test.assertEquals
 class U128ToIntTest {
 
     @Test
-    fun `U128 toInt() converts to equivalent Int`() {
+    fun `U128 toInt converts to equivalent Int`() {
         // given
         val intValue = 1234
         val u128 = U128.parse("1234")
@@ -20,7 +20,7 @@ class U128ToIntTest {
     }
 
     @Test
-    fun `U128 toInt() converts max value Int`() {
+    fun `U128 toInt converts max value Int`() {
         // given
         val intValue = Int.MAX_VALUE
         val u128 = U128.parse("2147483647")
@@ -33,7 +33,7 @@ class U128ToIntTest {
     }
 
     @Test
-    fun `U128 toInt() converts to truncated Int`() {
+    fun `U128 toInt converts to truncated Int`() {
         // given
         val longValue = 2147483652
         val u128 = U128.parse("2147483652")

--- a/core/src/commonTest/kotlin/com/solana/types/u128/U128ToLongTest.kt
+++ b/core/src/commonTest/kotlin/com/solana/types/u128/U128ToLongTest.kt
@@ -7,7 +7,7 @@ import kotlin.test.assertEquals
 class U128ToLongTest {
 
     @Test
-    fun `U128 toLong() converts to equivalent Long`() {
+    fun `U128 toLong converts to equivalent Long`() {
         // given
         val longValue = 1234L
         val u128 = U128.parse("1234")
@@ -20,7 +20,7 @@ class U128ToLongTest {
     }
 
     @Test
-    fun `U128 toLong() converts max value long`() {
+    fun `U128 toLong converts max value long`() {
         // given
         val longValue = Long.MAX_VALUE
         val u128 = U128.parse(longValue.toString())
@@ -33,7 +33,7 @@ class U128ToLongTest {
     }
 
     @Test
-    fun `U128 toLong() converts truncated Long`() {
+    fun `U128 toLong converts truncated Long`() {
         // given
         val u128 = U128.parse("18446744073709551621") // 2^64 + 5
         val expected = 5L
@@ -46,7 +46,7 @@ class U128ToLongTest {
     }
 
     @Test
-    fun `U128 toLong() converts 2^64 to zero`() {
+    fun `U128 toLong converts 2^64 to zero`() {
         // given
         val u128 = U128.parse("18446744073709551616") // 2^64
         val expected = 0L
@@ -59,7 +59,7 @@ class U128ToLongTest {
     }
 
     @Test
-    fun `U128 toLong() converts 2^127 to zero`() {
+    fun `U128 toLong converts 2^127 to zero`() {
         // given
         val u128 = U128.parse("170141183460469231731687303715884105728") // 2^127
         val expected = 0L

--- a/core/src/commonTest/kotlin/com/solana/types/u128/U128ToLongTest.kt
+++ b/core/src/commonTest/kotlin/com/solana/types/u128/U128ToLongTest.kt
@@ -1,0 +1,73 @@
+package com.solana.types.u128
+
+import com.solana.types.U128
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class U128ToLongTest {
+
+    @Test
+    fun `U128 toLong() converts to equivalent Long`() {
+        // given
+        val longValue = 1234L
+        val u128 = U128.parse("1234")
+
+        // when
+        val result = u128.toLong()
+
+        // then
+        assertEquals(longValue, result)
+    }
+
+    @Test
+    fun `U128 toLong() converts max value long`() {
+        // given
+        val longValue = Long.MAX_VALUE
+        val u128 = U128.parse(longValue.toString())
+
+        // when
+        val result = u128.toLong()
+
+        // then
+        assertEquals(longValue, result)
+    }
+
+    @Test
+    fun `U128 toLong() converts truncated Long`() {
+        // given
+        val u128 = U128.parse("18446744073709551621") // 2^64 + 5
+        val expected = 5L
+
+        // when
+        val result = u128.toLong()
+
+        // then
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun `U128 toLong() converts 2^64 to zero`() {
+        // given
+        val u128 = U128.parse("18446744073709551616") // 2^64
+        val expected = 0L
+
+        // when
+        val result = u128.toLong()
+
+        // then
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun `U128 toLong() converts 2^127 to zero`() {
+        // given
+        val u128 = U128.parse("170141183460469231731687303715884105728") // 2^127
+        val expected = 0L
+
+        // when
+        val result = u128.toLong()
+
+        // then
+        assertEquals(expected, result)
+    }
+}

--- a/core/src/commonTest/kotlin/com/solana/types/u128/U128ToShortTest.kt
+++ b/core/src/commonTest/kotlin/com/solana/types/u128/U128ToShortTest.kt
@@ -1,0 +1,49 @@
+package com.solana.types.u128
+
+import com.solana.types.U128
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class U128ToShortTest {
+
+    @Test
+    fun `U128 toShort() converts to equivalent Short`() {
+        // given
+        val shortValue: Short = 1234
+        val u128 = U128.parse("1234")
+
+        // when
+        val result = u128.toShort()
+
+        // then
+        assertEquals(shortValue, result)
+    }
+
+    @Test
+    fun `U128 toShort() converts max value Short`() {
+        // given
+        val shortValue: Short = Short.MAX_VALUE // 32767
+        val u128 = U128.parse("32767")
+
+        // when
+        val result = u128.toShort()
+
+        // then
+        assertEquals(shortValue, result)
+    }
+
+    @Test
+    fun `U128 toShort() converts to truncated Short`() {
+        // given
+        val intValue = 40000 // larger than Short.MAX_VALUE
+        val u128 = U128.parse(intValue.toString())
+        val expected = intValue.toShort() // truncates to -25536
+
+        // when
+        val result = u128.toShort()
+
+        // then
+        assertEquals(expected, result)
+    }
+
+}

--- a/core/src/commonTest/kotlin/com/solana/types/u128/U128ToShortTest.kt
+++ b/core/src/commonTest/kotlin/com/solana/types/u128/U128ToShortTest.kt
@@ -7,7 +7,7 @@ import kotlin.test.assertEquals
 class U128ToShortTest {
 
     @Test
-    fun `U128 toShort() converts to equivalent Short`() {
+    fun `U128 toShort converts to equivalent Short`() {
         // given
         val shortValue: Short = 1234
         val u128 = U128.parse("1234")
@@ -20,7 +20,7 @@ class U128ToShortTest {
     }
 
     @Test
-    fun `U128 toShort() converts max value Short`() {
+    fun `U128 toShort converts max value Short`() {
         // given
         val shortValue: Short = Short.MAX_VALUE // 32767
         val u128 = U128.parse("32767")
@@ -33,7 +33,7 @@ class U128ToShortTest {
     }
 
     @Test
-    fun `U128 toShort() converts to truncated Short`() {
+    fun `U128 toShort converts to truncated Short`() {
         // given
         val intValue = 40000 // larger than Short.MAX_VALUE
         val u128 = U128.parse(intValue.toString())

--- a/core/src/commonTest/kotlin/com/solana/types/u128/U128ToStringTest.kt
+++ b/core/src/commonTest/kotlin/com/solana/types/u128/U128ToStringTest.kt
@@ -1,0 +1,48 @@
+package com.solana.types.u128
+
+import com.solana.types.U128
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class U128ToStringTest {
+
+    @Test
+    fun `U128 toString returns max value as string`() {
+        // given
+        val u128 = U128.MAX_VALUE
+        val expectedString = "340282366920938463463374607431768211455"
+
+        // when
+        val actualString = u128.toString()
+
+        // then
+        assertEquals(expectedString, actualString)
+    }
+
+    @Test
+    fun `U128 toString for smaller number returns non-zero-padded string`() {
+        // given
+        val u128 = U128.parse("1234")
+        val expectedString = "1234"
+
+        // when
+        val actualString = u128.toString()
+
+        // then
+        assertEquals(expectedString, actualString)
+        assertEquals("0", U128.parse("0").toString())
+    }
+
+    @Test
+    fun `U128 toString for zero value returns 0 string`() {
+        // given
+        val u128 = U128.parse("0")
+        val expectedString = "0"
+
+        // when
+        val actualString = u128.toString()
+
+        // then
+        assertEquals(expectedString, actualString)
+    }
+}

--- a/core/src/commonTest/kotlin/com/solana/types/u256/U256CompareToTest.kt
+++ b/core/src/commonTest/kotlin/com/solana/types/u256/U256CompareToTest.kt
@@ -1,0 +1,50 @@
+package com.solana.types.u256
+
+import com.solana.types.U256
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class U256CompareToTest {
+
+    @Test
+    fun `U256 compareTo returns 0 for equivalent U256 values`() {
+        // given
+        val firstU256 = U256.parse("1234567890")
+        val otherU256 = U256.parse("1234567890")
+        val expectedComparison = 0
+
+        // when
+        val actualComparison = firstU256.compareTo(otherU256)
+
+        // then
+        assertEquals(expectedComparison, actualComparison)
+    }
+
+    @Test
+    fun `U256 compareTo returns -1 for comparison to larger U256 value`() {
+        // given
+        val firstU256 = U256.parse("1234567890")
+        val otherU256 = U256.parse("1234567891")
+        val expectedComparison = -1
+
+        // when
+        val actualComparison = firstU256.compareTo(otherU256)
+
+        // then
+        assertEquals(expectedComparison, actualComparison)
+    }
+
+    @Test
+    fun `U256 compareTo returns -1 for equivalent U256 values`() {
+        // given
+        val firstU256 = U256.parse("1234567891")
+        val otherU256 = U256.parse("1234567890")
+        val expectedComparison = 1
+
+        // when
+        val actualComparison = firstU256.compareTo(otherU256)
+
+        // then
+        assertEquals(expectedComparison, actualComparison)
+    }
+}

--- a/core/src/commonTest/kotlin/com/solana/types/u256/U256DivideTest.kt
+++ b/core/src/commonTest/kotlin/com/solana/types/u256/U256DivideTest.kt
@@ -45,7 +45,7 @@ class U256DivideTest {
         fun result() = dividend/divisor
 
         // then
-        assertFailsWith(ArithmeticException::class) {
+        assertFailsWith<Exception>("divide by zero") {
             result()
         }
     }

--- a/core/src/commonTest/kotlin/com/solana/types/u256/U256DivideTest.kt
+++ b/core/src/commonTest/kotlin/com/solana/types/u256/U256DivideTest.kt
@@ -1,0 +1,22 @@
+package com.solana.types.u256
+
+import com.solana.types.U256
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class U256DivideTest {
+
+    @Test
+    fun `divide U128 value by long produces integer division result`() {
+        // given
+        val dividend = U256.parse("2378567835")
+        val divisor = 1256L
+        val expectedResult = U256.parse("1893764")
+
+        // when
+        val product = dividend/divisor
+
+        // then
+        assertEquals(expectedResult, product)
+    }
+}

--- a/core/src/commonTest/kotlin/com/solana/types/u256/U256DivideTest.kt
+++ b/core/src/commonTest/kotlin/com/solana/types/u256/U256DivideTest.kt
@@ -3,20 +3,50 @@ package com.solana.types.u256
 import com.solana.types.U256
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 
 class U256DivideTest {
 
     @Test
-    fun `divide U128 value by long produces integer division result`() {
+    fun `divide U256 value by long produces integer division result`() {
         // given
         val dividend = U256.parse("2378567835")
         val divisor = 1256L
         val expectedResult = U256.parse("1893764")
 
         // when
-        val product = dividend/divisor
+        val result = dividend/divisor
 
         // then
-        assertEquals(expectedResult, product)
+        assertEquals(expectedResult, result)
+    }
+
+    @Test
+    fun `divide U256 0 value by long produces 0`() {
+        // given
+        val dividend = U256.parse("0")
+        val divisor = 1256L
+        val expectedResult = U256.parse("0")
+
+        // when
+        val result = dividend/divisor
+
+        // then
+        assertEquals(expectedResult, result)
+    }
+
+    @Test
+    fun `divide U256 value by 0 produces Error`() {
+        // given
+        val dividend = U256.parse("324862882325")
+        val divisor = 0L
+
+        // when
+        fun result() = dividend/divisor
+
+        // then
+        assertFailsWith(ArithmeticException::class) {
+            result()
+        }
     }
 }

--- a/core/src/commonTest/kotlin/com/solana/types/u256/U256ParseTest.kt
+++ b/core/src/commonTest/kotlin/com/solana/types/u256/U256ParseTest.kt
@@ -1,0 +1,144 @@
+package com.solana.types.u256
+
+import com.solana.types.U256
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class U256ParseTest {
+
+    @Test
+    fun `parse Int string successfully parses Int value`() {
+        // given
+        val intString = "1234"
+        val expected = byteArrayOf(
+            -46, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
+        ) // 1234 bytes, little-endian
+
+        // when
+        val result = U256.parse(intString)
+
+        // then
+        assertContentEquals(expected, result.toByteArray())
+    }
+
+    @Test
+    fun `parse U256 max value string successfully parses`() {
+        // given
+        val u256String = U256.MAX_VALUE_DECIMAL
+        val expected = U256.MAX_VALUE
+
+        // when
+        val result = U256.parse(u256String)
+
+        // then
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun `parse U256 min value string successfully parses`() {
+        // given
+        val zeroString = "0"
+        val expected = U256.MIN_VALUE
+
+        // when
+        val result = U256.parse(zeroString)
+
+        // then
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun `parse empty string throws IllegalArgumentException`() {
+        // given
+        val emptyString = ""
+
+        // then
+        assertFailsWith(IllegalArgumentException::class) {
+            U256.parse(emptyString)
+        }
+    }
+
+    @Test
+    fun `parse non-numeric string throws IllegalArgumentException`() {
+        // given
+        val illegalString = "1234abcd"
+
+        // then
+        assertFailsWith(IllegalArgumentException::class) {
+            U256.parse(illegalString)
+        }
+    }
+
+    @Test
+    fun `parse input string greater than U256 MAX_VALUE throws IllegalArgumentException`() {
+        // given
+        val u257String = "115792089237316195423570985008687907853269984665640564039457584007913129639936" // U256.MAX_VALUE + 1
+
+        // then
+        assertFailsWith(IllegalArgumentException::class) {
+            U256.parse(u257String)
+        }
+    }
+
+    @Test
+    fun `parse UInt string successfully parses UInt value`() {
+        // given
+        val intString = "1234u"
+        val expected = byteArrayOf(
+            -46, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
+        ) // 1234 bytes, little-endian
+
+        // when
+        val result = U256.parse(intString)
+
+        // then
+        assertContentEquals(expected, result.toByteArray())
+    }
+
+    @Test
+    fun `parse underscore separated string successfully parses value`() {
+        // given
+        val intString = "1_234"
+        val expected = byteArrayOf(
+            -46, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
+        ) // 1234 bytes, little-endian
+
+        // when
+        val result = U256.parse(intString)
+
+        // then
+        assertContentEquals(expected, result.toByteArray())
+    }
+
+    @Test
+    fun `parse BigInt literal string successfully parses value`() {
+        // given
+        val intString = "1234n"
+        val expected = byteArrayOf(
+            -46, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
+        ) // 1234 bytes, little-endian
+
+        // when
+        val result = U256.parse(intString)
+
+        // then
+        assertContentEquals(expected, result.toByteArray())
+    }
+
+    @Test
+    fun `parse underscore separated BigInt literal string successfully parses value`() {
+        // given
+        val intString = "1_234n"
+        val expected = byteArrayOf(
+            -46, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
+        ) // 1234 bytes, little-endian
+
+        // when
+        val result = U256.parse(intString)
+
+        // then
+        assertContentEquals(expected, result.toByteArray())
+    }
+}

--- a/core/src/commonTest/kotlin/com/solana/types/u256/U256SerializationTest.kt
+++ b/core/src/commonTest/kotlin/com/solana/types/u256/U256SerializationTest.kt
@@ -1,0 +1,131 @@
+package com.solana.types.u256
+
+import com.funkatronics.kborsh.Borsh
+import com.solana.types.U256
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.encodeToByteArray
+import kotlinx.serialization.json.Json
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+
+class U256SerializationTest {
+
+    @Test
+    fun `U256 serializes to JSON as string`() {
+        // given
+        @Serializable
+        data class TestClass(val u256: U256)
+        val u256 = U256.parse("12345")
+        val expectedJson = """
+            {"u256":"12345"}
+        """.trimIndent()
+
+        // when
+        val actualJson = Json.encodeToString<TestClass>(TestClass(u256))
+
+        // then
+        assertEquals(expectedJson, actualJson)
+    }
+
+    @Test
+    fun `U256 serializes small number to Borsh as 16 length byte string`() {
+        // given
+        @Serializable
+        data class TestClass(val u256: U256)
+        val u256 = U256.parse("12345")
+        val expectedBinary = byteArrayOf(
+            57, 48, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
+        )
+
+        // when
+        val actualBinary = Borsh.encodeToByteArray<TestClass>(TestClass(u256))
+
+        // then
+        assertContentEquals(expectedBinary, actualBinary)
+    }
+
+    @Test
+    fun `U256 serializes medium number to Borsh as 16 length byte string`() {
+        // given
+        @Serializable
+        data class TestClass(val u256: U256)
+        val u256 = U256.parse("9223372036854775810")
+        val expectedBinary = byteArrayOf(
+            2, 0, 0, 0, 0, 0, 0, -128, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
+        )
+        // when
+        val actualBinary = Borsh.encodeToByteArray<TestClass>(TestClass(u256))
+
+        // then
+        assertContentEquals(expectedBinary, actualBinary)
+    }
+
+    @Test
+    fun `U256 serializes large number to Borsh as 16 length byte string`() {
+        // given
+        @Serializable
+        data class TestClass(val u256: U256)
+        val u256 = U256.parse("987654321012345678901234567890")
+        val expectedBinary = byteArrayOf(
+            -46, 10, -65, -41, -116, -128, 101, 80, -103, -127, 72, 119, 12, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
+        )
+        // when
+        val actualBinary = Borsh.encodeToByteArray<TestClass>(TestClass(u256))
+
+        // then
+        assertContentEquals(expectedBinary, actualBinary)
+    }
+
+    @Test
+    fun `U256 serializes MAX_VALUE to Borsh as max value ByteArray`() {
+        // given
+        @Serializable
+        data class TestClass(val u256: U256)
+        val u256 = U256.MAX_VALUE
+        val expectedBinary = byteArrayOf(
+            -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1
+        )
+
+        // when
+        val actualBinary = Borsh.encodeToByteArray<TestClass>(TestClass(u256))
+
+        // then
+        assertContentEquals(expectedBinary, actualBinary)
+    }
+
+    @Test
+    fun `Class containing U256 values serializes to Borsh ByteArray`() {
+        // given
+        @Serializable
+        data class TestClass(
+            val string: String,
+            val u256a: U256,
+            val u256b: U256,
+            val boolean: Boolean,
+            val u256c: U256
+        )
+        val testInstance = TestClass(
+            "Hello World!",
+            U256.MAX_VALUE,
+            U256.MIN_VALUE,
+            false,
+            U256.parse("1234567890")
+        )
+        val expectedBinary = byteArrayOf(
+            12, 0, 0, 0, 72, 101, 108, 108, 111, 32, 87, 111, 114, 108, 100, 33, // "Hello World!"
+            -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, // U256.MAX_VALUE
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, // U256.MIN_VALUE
+            0, // false boolean
+            -46, 2, -106, 73, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 // U256(1234567890)
+        )
+
+        // when
+        val actualBinary = Borsh.encodeToByteArray<TestClass>(testInstance)
+        val actualDecoded = Borsh.decodeFromByteArray(TestClass.serializer(), actualBinary)
+
+        // then
+        assertContentEquals(expectedBinary, actualBinary)
+        assertEquals(testInstance, actualDecoded)
+    }
+}

--- a/core/src/commonTest/kotlin/com/solana/types/u256/U256ToByteTest.kt
+++ b/core/src/commonTest/kotlin/com/solana/types/u256/U256ToByteTest.kt
@@ -1,0 +1,48 @@
+package com.solana.types.u256
+
+import com.solana.types.U256
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class U256ToByteTest {
+
+    @Test
+    fun `U256 toByte converts to equivalent Byte`() {
+        // given
+        val byteValue: Byte = 123
+        val u256 = U256.parse("123")
+
+        // when
+        val result = u256.toByte()
+
+        // then
+        assertEquals(byteValue, result)
+    }
+
+    @Test
+    fun `U256 toByte converts max value Byte`() {
+        // given
+        val byteValue: Byte = Byte.MAX_VALUE // 127
+        val u256 = U256.parse("127")
+
+        // when
+        val result = u256.toByte()
+
+        // then
+        assertEquals(byteValue, result)
+    }
+
+    @Test
+    fun `U256 toByte converts to truncated Byte`() {
+        // given
+        val intValue = 300 // larger than Byte.MAX_VALUE
+        val u256 = U256.parse(intValue.toString())
+        val expected = intValue.toByte() // truncates to 44
+
+        // when
+        val result = u256.toByte()
+
+        // then
+        assertEquals(expected, result)
+    }
+}

--- a/core/src/commonTest/kotlin/com/solana/types/u256/U256ToDoubleTest.kt
+++ b/core/src/commonTest/kotlin/com/solana/types/u256/U256ToDoubleTest.kt
@@ -1,0 +1,49 @@
+package com.solana.types.u256
+
+import com.solana.types.U256
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class U256ToDoubleTest {
+
+    @Test
+    fun `U256 toDouble converts to equivalent Double for small values`() {
+        // given
+        val u256 = U256.parse("12345")
+        val expected = 12345.0
+
+        // when
+        val result = u256.toDouble()
+
+        // then
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun `U256 toDouble converts max precise integer within Double mantissa`() {
+        // given
+        // 2^53 = 9007199254740992 is the largest integer exactly representable in Double
+        val value = 9007199254740992UL
+        val u256 = U256.parse(value.toString())
+        val expected = 9007199254740992.0
+
+        // when
+        val result = u256.toDouble()
+
+        // then
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun `U256 toDouble converts max U256 value with expected precision loss`() {
+        // given
+        val u256 = U256.MAX_VALUE
+        val expected = 3.402823669209385E38
+
+        // when
+        val result = u256.toDouble()
+
+        // then
+        assertEquals(expected, result, 1e-9)
+    }
+}

--- a/core/src/commonTest/kotlin/com/solana/types/u256/U256ToFloatTest.kt
+++ b/core/src/commonTest/kotlin/com/solana/types/u256/U256ToFloatTest.kt
@@ -1,0 +1,50 @@
+package com.solana.types.u256
+
+import com.solana.types.U256
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class U256ToFloatTest {
+
+    @Test
+    fun `U256 toFloat converts small values exactly`() {
+        // given
+        val u256 = U256.parse("12345")
+        val expected = 12345f
+
+        // when
+        val result = u256.toFloat()
+
+        // then
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun `U256 toFloat converts max precise integer within Float mantissa`() {
+        // given
+        // 2^24 = 16777216 is the largest integer exactly representable in Float
+        val value = 16777216UL
+        val u256 = U256.parse(value.toString())
+        val expected = 16777216f
+
+        // when
+        val result = u256.toFloat()
+
+        // then
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun `U256 toFloat converts imprecise but finite values larger than 2^24`() {
+        // given
+        val bigButFinite = 100_000_000UL // > 2^24 but << Float.MAX_VALUE
+        val u256 = U256.parse(bigButFinite.toString())
+        val expected = 100_000_000f
+
+        // when
+        val result = u256.toFloat()
+
+        // then
+        assertEquals(expected, result, 0.0001f)
+    }
+}

--- a/core/src/commonTest/kotlin/com/solana/types/u256/U256ToIntTest.kt
+++ b/core/src/commonTest/kotlin/com/solana/types/u256/U256ToIntTest.kt
@@ -1,0 +1,48 @@
+package com.solana.types.u256
+
+import com.solana.types.U256
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class U256ToIntTest {
+
+    @Test
+    fun `U256 toInt converts to equivalent Int`() {
+        // given
+        val intValue = 1234
+        val u256 = U256.parse("1234")
+
+        // when
+        val result = u256.toInt()
+
+        // then
+        assertEquals(intValue, result)
+    }
+
+    @Test
+    fun `U256 toInt converts max value Int`() {
+        // given
+        val intValue = Int.MAX_VALUE
+        val u256 = U256.parse("2147483647")
+
+        // when
+        val result = u256.toInt()
+
+        // then
+        assertEquals(intValue, result)
+    }
+
+    @Test
+    fun `U256 toInt converts to truncated Int`() {
+        // given
+        val longValue = 2147483652
+        val u256 = U256.parse("2147483652")
+        val expected = longValue.toInt()
+
+        // when
+        val result = u256.toInt()
+
+        // then
+        assertEquals(expected, result)
+    }
+}

--- a/core/src/commonTest/kotlin/com/solana/types/u256/U256ToLongTest.kt
+++ b/core/src/commonTest/kotlin/com/solana/types/u256/U256ToLongTest.kt
@@ -1,0 +1,73 @@
+package com.solana.types.u256
+
+import com.solana.types.U256
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class U256ToLongTest {
+
+    @Test
+    fun `U256 toLong converts to equivalent Long`() {
+        // given
+        val longValue = 1234L
+        val u256 = U256.parse("1234")
+
+        // when
+        val result = u256.toLong()
+
+        // then
+        assertEquals(longValue, result)
+    }
+
+    @Test
+    fun `U256 toLong converts max value long`() {
+        // given
+        val longValue = Long.MAX_VALUE
+        val u256 = U256.parse(longValue.toString())
+
+        // when
+        val result = u256.toLong()
+
+        // then
+        assertEquals(longValue, result)
+    }
+
+    @Test
+    fun `U256 toLong converts truncated Long`() {
+        // given
+        val u256 = U256.parse("18446744073709551621") // 2^64 + 5
+        val expected = 5L
+
+        // when
+        val result = u256.toLong()
+
+        // then
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun `U256 toLong converts 2^64 to zero`() {
+        // given
+        val u256 = U256.parse("18446744073709551616") // 2^64
+        val expected = 0L
+
+        // when
+        val result = u256.toLong()
+
+        // then
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun `U256 toLong converts 2^127 to zero`() {
+        // given
+        val u256 = U256.parse("170141183460469231731687303715884105728") // 2^127
+        val expected = 0L
+
+        // when
+        val result = u256.toLong()
+
+        // then
+        assertEquals(expected, result)
+    }
+}

--- a/core/src/commonTest/kotlin/com/solana/types/u256/U256ToShortTest.kt
+++ b/core/src/commonTest/kotlin/com/solana/types/u256/U256ToShortTest.kt
@@ -1,0 +1,49 @@
+package com.solana.types.u256
+
+import com.solana.types.U256
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class U256ToShortTest {
+
+    @Test
+    fun `U256 toShort converts to equivalent Short`() {
+        // given
+        val shortValue: Short = 1234
+        val u256 = U256.parse("1234")
+
+        // when
+        val result = u256.toShort()
+
+        // then
+        assertEquals(shortValue, result)
+    }
+
+    @Test
+    fun `U256 toShort converts max value Short`() {
+        // given
+        val shortValue: Short = Short.MAX_VALUE // 32767
+        val u256 = U256.parse("32767")
+
+        // when
+        val result = u256.toShort()
+
+        // then
+        assertEquals(shortValue, result)
+    }
+
+    @Test
+    fun `U256 toShort converts to truncated Short`() {
+        // given
+        val intValue = 40000 // larger than Short.MAX_VALUE
+        val u256 = U256.parse(intValue.toString())
+        val expected = intValue.toShort() // truncates to -25536
+
+        // when
+        val result = u256.toShort()
+
+        // then
+        assertEquals(expected, result)
+    }
+
+}

--- a/core/src/commonTest/kotlin/com/solana/types/u256/U256ToStringTest.kt
+++ b/core/src/commonTest/kotlin/com/solana/types/u256/U256ToStringTest.kt
@@ -1,0 +1,48 @@
+package com.solana.types.u256
+
+import com.solana.types.U256
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class U256ToStringTest {
+
+    @Test
+    fun `U256 toString returns max value as string`() {
+        // given
+        val u256 = U256.MAX_VALUE
+        val expectedString = "115792089237316195423570985008687907853269984665640564039457584007913129639935"
+
+        // when
+        val actualString = u256.toString()
+
+        // then
+        assertEquals(expectedString, actualString)
+    }
+
+    @Test
+    fun `U256 toString for smaller number returns non-zero-padded string`() {
+        // given
+        val u256 = U256.parse("1234")
+        val expectedString = "1234"
+
+        // when
+        val actualString = u256.toString()
+
+        // then
+        assertEquals(expectedString, actualString)
+        assertEquals("0", U256.parse("0").toString())
+    }
+
+    @Test
+    fun `U256 toString for zero value returns 0 string`() {
+        // given
+        val u256 = U256.parse("0")
+        val expectedString = "0"
+
+        // when
+        val actualString = u256.toString()
+
+        // then
+        assertEquals(expectedString, actualString)
+    }
+}

--- a/core/src/jsTest/kotlin/com/solana/types/u128/U128ToFloatTestJs.kt
+++ b/core/src/jsTest/kotlin/com/solana/types/u128/U128ToFloatTestJs.kt
@@ -1,0 +1,23 @@
+package com.solana.types.u128
+
+import com.solana.types.U128
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class U128ToFloatTestJs {
+
+    @Test
+    fun `U128 toFloat converts max U128 value with expected precision loss`() {
+        // given
+        val u128 = U128.MAX_VALUE
+        val expected = 3.402823669209385E38
+
+        // when
+        val result = u128.toFloat()
+
+        // then
+        assertTrue(u128.toFloat().isFinite())
+        assertEquals(expected, result.toDouble())
+    }
+}

--- a/core/src/jsTest/kotlin/com/solana/types/u256/U256ToFloatTestJs.kt
+++ b/core/src/jsTest/kotlin/com/solana/types/u256/U256ToFloatTestJs.kt
@@ -1,0 +1,23 @@
+package com.solana.types.u256
+
+import com.solana.types.U256
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class U256ToFloatTestJs {
+
+    @Test
+    fun `U256 toFloat converts max U256 value with expected precision loss`() {
+        // given
+        val u256 = U256.MAX_VALUE
+        val expected = 3.402823669209385E38
+
+        // when
+        val result = u256.toFloat()
+
+        // then
+        assertTrue(u256.toFloat().isFinite())
+        assertEquals(expected, result.toDouble())
+    }
+}

--- a/core/src/jvmTest/kotlin/com/solana/types/u128/U128ToFloatTestJvm.kt
+++ b/core/src/jvmTest/kotlin/com/solana/types/u128/U128ToFloatTestJvm.kt
@@ -1,0 +1,21 @@
+package com.solana.types.u128
+
+import com.solana.types.U128
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class U128ToFloatTestJvm {
+
+    @Test
+    fun `U128 toFloat converts max U128 with expected overflow to Infinity`() {
+        // given
+        val u128 = U128.MAX_VALUE
+        val expected = Float.POSITIVE_INFINITY
+
+        // when
+        val result = u128.toFloat()
+
+        // then
+        assertEquals(expected, result)
+    }
+}

--- a/core/src/jvmTest/kotlin/com/solana/types/u256/U256ToFloatTestJvm.kt
+++ b/core/src/jvmTest/kotlin/com/solana/types/u256/U256ToFloatTestJvm.kt
@@ -1,0 +1,21 @@
+package com.solana.types.u256
+
+import com.solana.types.U256
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class U256ToFloatTestJvm {
+
+    @Test
+    fun `U256 toFloat converts max U256 with expected overflow to Infinity`() {
+        // given
+        val u256 = U256.MAX_VALUE
+        val expected = Float.POSITIVE_INFINITY
+
+        // when
+        val result = u256.toFloat()
+
+        // then
+        assertEquals(expected, result)
+    }
+}

--- a/core/src/nativeTest/kotlin/com/solana/types/u128/U128ToFloatTestNative.kt
+++ b/core/src/nativeTest/kotlin/com/solana/types/u128/U128ToFloatTestNative.kt
@@ -1,0 +1,21 @@
+package com.solana.types.u128
+
+import com.solana.types.U128
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class U128ToFloatTestNative {
+
+    @Test
+    fun `U128 toFloat converts max U128 with expected overflow to Infinity`() {
+        // given
+        val u128 = U128.MAX_VALUE
+        val expected = Float.POSITIVE_INFINITY
+
+        // when
+        val result = u128.toFloat()
+
+        // then
+        assertEquals(expected, result)
+    }
+}

--- a/core/src/nativeTest/kotlin/com/solana/types/u256/U256ToFloatTestNative.kt
+++ b/core/src/nativeTest/kotlin/com/solana/types/u256/U256ToFloatTestNative.kt
@@ -1,0 +1,21 @@
+package com.solana.types.u256
+
+import com.solana.types.U256
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class U256ToFloatTestNative {
+
+    @Test
+    fun `U256 toFloat converts max U256 with expected overflow to Infinity`() {
+        // given
+        val u256 = U256.MAX_VALUE
+        val expected = Float.POSITIVE_INFINITY
+
+        // when
+        val result = u256.toFloat()
+
+        // then
+        assertEquals(expected, result)
+    }
+}


### PR DESCRIPTION
Adds unsigned 128 & 256 bit integer types to web3-core

U128/256 uses a little endian 16/32 byte array under the hood and serializes the same for Borsh encoding. When serialized as JSON, the number is encoded as a base10 string. 