### PR TITLE
ATA: createIdempotent

### DIFF
--- a/solana/src/commonMain/kotlin/com/solana/programs/AssociatedTokenProgram.kt
+++ b/solana/src/commonMain/kotlin/com/solana/programs/AssociatedTokenProgram.kt
@@ -9,6 +9,9 @@ object AssociatedTokenProgram : Program {
     @JvmStatic
     val PROGRAM_ID = SolanaPublicKey.from("ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL")
 
+    private const val PROGRAM_INDEX_CREATE_IDEMPOTENT = 1
+    private const val PROGRAM_INDEX_RECOVER_NESTED = 2
+
     @JvmStatic
     fun createAssociatedTokenAccount(
         mint: SolanaPublicKey,
@@ -30,6 +33,39 @@ object AssociatedTokenProgram : Program {
                 AccountMeta(TokenProgram.SYSVAR_RENT_PUBKEY, false, false)
             ),
             data = byteArrayOf()
+        )
+
+    @JvmStatic
+    fun create(
+        payer: SolanaPublicKey,
+        associatedAccount: SolanaPublicKey,
+        owner: SolanaPublicKey,
+        mint: SolanaPublicKey,
+        programId: SolanaPublicKey = TokenProgram.PROGRAM_ID,
+        associatedProgramId: SolanaPublicKey = PROGRAM_ID,
+    ) = createAssociatedTokenAccount(mint, associatedAccount, owner, payer, associatedProgramId, programId)
+
+    @JvmStatic
+    fun createIdempotent(
+        payer: SolanaPublicKey,
+        associatedAccount: SolanaPublicKey,
+        owner: SolanaPublicKey,
+        mint: SolanaPublicKey,
+        programId: SolanaPublicKey = TokenProgram.PROGRAM_ID,
+        associatedProgramId: SolanaPublicKey = PROGRAM_ID,
+    ): TransactionInstruction =
+        TransactionInstruction(
+            associatedProgramId,
+            listOf(
+                AccountMeta(payer, true, true),
+                AccountMeta(associatedAccount, false, true),
+                AccountMeta(owner, false, false),
+                AccountMeta(mint, false, false),
+                AccountMeta(SystemProgram.PROGRAM_ID, false, false),
+                AccountMeta(programId, false, false),
+                AccountMeta(TokenProgram.SYSVAR_RENT_PUBKEY, false, false)
+            ),
+            data = byteArrayOf(PROGRAM_INDEX_CREATE_IDEMPOTENT.toByte())
         )
 
     override val programId = PROGRAM_ID

--- a/solana/src/commonTest/kotlin/com/solana/programs/AssociatedTokenProgramTests.kt
+++ b/solana/src/commonTest/kotlin/com/solana/programs/AssociatedTokenProgramTests.kt
@@ -9,6 +9,7 @@ import com.solana.rpc.SolanaRpcClient
 import com.solana.rpc.TransactionOptions
 import com.solana.transaction.Message
 import com.solana.transaction.Transaction
+import com.solana.transaction.buildSignedTransaction
 import diglol.crypto.Ed25519
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.test.runTest
@@ -101,5 +102,196 @@ class AssociatedTokenProgramTests {
         assertNotNull(accountInfo.result)
         assertEquals(TokenProgram.programId, accountInfo.result!!.owner)
         assertEquals(165, accountInfo.result!!.space!!.toInt())
+    }
+
+    @Test
+    fun `createIdempotent successfully creates ATA`() = runTest {
+        // given
+        val mint = Ed25519.generateKeyPair()
+        val mintAuthority = Ed25519.generateKeyPair()
+        val mintPublicKey = SolanaPublicKey(mint.publicKey)
+        val mintAuthorityPublicKey = SolanaPublicKey(mintAuthority.publicKey)
+        val owner = Ed25519.generateKeyPair()
+        val ownerPublicKey = SolanaPublicKey(owner.publicKey)
+        val rpc = SolanaRpcClient(TestConfig.RPC_URL, KtorNetworkDriver())
+
+        val associatedAccount = SolanaPublicKey(ProgramDerivedAddress.find(
+            listOf(ownerPublicKey.bytes, TokenProgram.PROGRAM_ID.bytes, mintPublicKey.bytes),
+            AssociatedTokenProgram.PROGRAM_ID
+        ).getOrThrow().bytes)
+
+        // when
+        rpc.requestAirdrop(ownerPublicKey, 0.1f)
+        rpc.requestAirdrop(mintAuthorityPublicKey, 0.1f)
+
+        val rentExemptBalanceResponse = rpc.getMinBalanceForRentExemption(82)
+        var blockhashResponse = rpc.getLatestBlockhash()
+        val createAndInitializeMintTransaction = Message.Builder()
+            .setRecentBlockhash(blockhashResponse.result!!.blockhash)
+            .addInstruction(SystemProgram.createAccount(
+                mintAuthorityPublicKey,
+                mintPublicKey,
+                rentExemptBalanceResponse.result!!,
+                82L,
+                TokenProgram.PROGRAM_ID
+            ))
+            .addInstruction(TokenProgram.initializeMint(
+                mintPublicKey,
+                10,
+                mintAuthorityPublicKey
+            ))
+            .build().run {
+                Transaction(listOf(
+                    Ed25519.sign(mintAuthority, serialize()),
+                    Ed25519.sign(mint, serialize())
+                ), this)
+            }
+
+        withContext(Dispatchers.Default.limitedParallelism(1)) {
+            rpc.sendAndConfirmTransaction(createAndInitializeMintTransaction, TransactionOptions(
+                commitment = Commitment.CONFIRMED,
+                skipPreflight = true
+            ))
+        }
+
+        blockhashResponse = rpc.getLatestBlockhash()
+        val transaction = Message.Builder()
+            .setRecentBlockhash(blockhashResponse.result!!.blockhash)
+            .addInstruction(AssociatedTokenProgram.createIdempotent(
+                ownerPublicKey,
+                associatedAccount,
+                ownerPublicKey,
+                mintPublicKey
+            ))
+            .build().run {
+                Transaction(listOf(
+                    Ed25519.sign(owner, serialize())
+                ), this)
+            }
+
+        withContext(Dispatchers.Default.limitedParallelism(1)) {
+            rpc.sendAndConfirmTransaction(transaction, TransactionOptions(
+                commitment = Commitment.CONFIRMED,
+                skipPreflight = true
+            )).apply {
+                assertNull(error)
+                assertNotNull(result)
+            }
+        }
+
+        val accountInfo = rpc.getAccountInfo(associatedAccount, commitment = Commitment.CONFIRMED)
+
+        assertNull(accountInfo.error)
+        assertNotNull(accountInfo.result)
+        assertEquals(TokenProgram.programId, accountInfo.result!!.owner)
+        assertEquals(165, accountInfo.result!!.space!!.toInt())
+    }
+
+    @Test
+    fun `createIdempotent maintains idempotency`() = runTest {
+        // given
+        val mint = Ed25519.generateKeyPair()
+        val mintAuthority = Ed25519.generateKeyPair()
+        val mintPublicKey = SolanaPublicKey(mint.publicKey)
+        val mintAuthorityPublicKey = SolanaPublicKey(mintAuthority.publicKey)
+        val owner = Ed25519.generateKeyPair()
+        val ownerPublicKey = SolanaPublicKey(owner.publicKey)
+        val rpc = SolanaRpcClient(TestConfig.RPC_URL, KtorNetworkDriver())
+
+        val associatedAccount = SolanaPublicKey(ProgramDerivedAddress.find(
+            listOf(ownerPublicKey.bytes, TokenProgram.PROGRAM_ID.bytes, mintPublicKey.bytes),
+            AssociatedTokenProgram.PROGRAM_ID
+        ).getOrThrow().bytes)
+
+        // when
+        rpc.requestAirdrop(ownerPublicKey, 0.1f)
+        rpc.requestAirdrop(mintAuthorityPublicKey, 0.1f)
+
+        val rentExemptBalanceResponse = rpc.getMinBalanceForRentExemption(82)
+        var blockhashResponse = rpc.getLatestBlockhash()
+        val createAndInitializeMintTransaction = Message.Builder()
+            .setRecentBlockhash(blockhashResponse.result!!.blockhash)
+            .addInstruction(SystemProgram.createAccount(
+                mintAuthorityPublicKey,
+                mintPublicKey,
+                rentExemptBalanceResponse.result!!,
+                82L,
+                TokenProgram.PROGRAM_ID
+            ))
+            .addInstruction(TokenProgram.initializeMint(
+                mintPublicKey,
+                10,
+                mintAuthorityPublicKey
+            ))
+            .build().run {
+                Transaction(listOf(
+                    Ed25519.sign(mintAuthority, serialize()),
+                    Ed25519.sign(mint, serialize())
+                ), this)
+            }
+
+        withContext(Dispatchers.Default.limitedParallelism(1)) {
+            rpc.sendAndConfirmTransaction(createAndInitializeMintTransaction, TransactionOptions(
+                commitment = Commitment.CONFIRMED,
+                skipPreflight = true
+            ))
+        }
+
+        blockhashResponse = rpc.getLatestBlockhash()
+        val createAtaTransaction = Message.Builder()
+            .setRecentBlockhash(blockhashResponse.result!!.blockhash)
+            .addInstruction(AssociatedTokenProgram.create(
+                ownerPublicKey,
+                associatedAccount,
+                ownerPublicKey,
+                mintPublicKey
+            ))
+            .build().run {
+                Transaction(listOf(
+                    Ed25519.sign(owner, serialize())
+                ), this)
+            }
+
+        withContext(Dispatchers.Default.limitedParallelism(1)) {
+            rpc.sendAndConfirmTransaction(createAtaTransaction, TransactionOptions(
+                commitment = Commitment.CONFIRMED,
+                skipPreflight = true
+            )).apply {
+                assertNull(error)
+                assertNotNull(result)
+            }
+        }
+
+        val accountInfo = rpc.getAccountInfo(associatedAccount, commitment = Commitment.CONFIRMED)
+
+        assertNull(accountInfo.error)
+        assertNotNull(accountInfo.result)
+        assertEquals(TokenProgram.programId, accountInfo.result!!.owner)
+        assertEquals(165, accountInfo.result!!.space!!.toInt())
+
+        blockhashResponse = rpc.getLatestBlockhash()
+        val transaction = Message.Builder()
+            .setRecentBlockhash(blockhashResponse.result!!.blockhash)
+            .addInstruction(AssociatedTokenProgram.createIdempotent(
+                ownerPublicKey,
+                associatedAccount,
+                ownerPublicKey,
+                mintPublicKey
+            ))
+            .build().run {
+                Transaction(listOf(
+                    Ed25519.sign(owner, serialize())
+                ), this)
+            }
+
+        withContext(Dispatchers.Default.limitedParallelism(1)) {
+            rpc.sendAndConfirmTransaction(transaction, TransactionOptions(
+                commitment = Commitment.CONFIRMED,
+                skipPreflight = true
+            )).apply {
+                assertNull(error)
+                assertNotNull(result)
+            }
+        }
     }
 }


### PR DESCRIPTION
Adds ATA programs `createIdempotent` instruction for creating ATAs with idempotency 